### PR TITLE
Add MountainWest JSConf to conferences

### DIFF
--- a/rawdata
+++ b/rawdata
@@ -1188,5 +1188,14 @@
         "lng": -93.2488,
         "state": "Minnesota",
         "town": "Minneapolis"
+    },
+    {
+        "continent": "Conference",
+        "country": "USA",
+        "lat": 40.761366,
+        "link": "http://mtnwestjsconf.org/",
+        "lng": -111.884251,
+        "town": "Salt Lake City",
+        "state": "Utah"
     }
 ]


### PR DESCRIPTION
We have a new conference in SLC, Utah, USA. Our CFP is now open.
